### PR TITLE
[GH-3][GH-4] remove output attribute - allow for additional config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Attributes
 - `node['logwatch']['email']` - Email Address which Logwatch reports to
 - `node['logwatch']['detail']` - The level of detail in the Logwatch report
 - `node['logwatch']['range']` - The default time range for the Logwatch report
-- `node['logwatch']['output']` - The output method of the Logwatch report
 - `node['logwatch']['format']` - The format of the Logwatch report
+- `node['logwatch']['directives']` - Additional configuration options can be added here, comma separated, for example: `default['logwatch']['directives'] = ['Print = Yes', 'Output = mail', 'Service = All']`
 
 
 License & Authors

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,5 +21,5 @@ default['logwatch']['email'] = 'root@localhost'
 default['logwatch']['sender'] = 'Logwatch'
 default['logwatch']['detail'] = 'Low'
 default['logwatch']['range']  = 'yesterday'
-default['logwatch']['output'] = 'stdout'
 default['logwatch']['format'] = 'text'
+default['logwatch']['directives'] = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,4 +27,7 @@ template '/etc/logwatch/conf/logwatch.conf' do
   owner 'root'
   group 'root'
   mode '0644'
+  variables(
+    directives: node['logwatch']['directives']
+  )
 end

--- a/templates/default/logwatch.conf.erb
+++ b/templates/default/logwatch.conf.erb
@@ -5,5 +5,7 @@ MailTo = <%= node['logwatch']['email'] %>
 MailFrom = <%= node['logwatch']['sender'] %>
 Detail = <%=  node['logwatch']['detail'] %>
 Range = <%= node['logwatch']['range'] %>
-Output = <%=  node['logwatch']['output'] %>
 Format = <%=  node['logwatch']['format'] %>
+<% @directives.each do |directive| %>
+<%= directive %>
+<% end %>


### PR DESCRIPTION
This will resolve issues #3 and #4 

* Removed the `default['logwatch']['output']` attribute: The 'Output' option changed functionality between logwatch versions 7.3.x (included with RHEL versions < 7) and 7.4. In logwatch versions 7.4.0+ the default option is already 'stdout' making the explicit attribute setting unnecessary.

* Added the `default['logwatch']['directives'] = []` attribute. Similar to the setting in the community squid cookbook attribute (https://github.com/chef-cookbooks/squid/blob/master/attributes/default.rb#L24) this allows for additional configuration options to be set.
